### PR TITLE
Bad Javadoc tag removal

### DIFF
--- a/emf/src/main/java/org/eclipse/epsilon/zeta/model/emf/util/EmfModelAssistant.java
+++ b/emf/src/main/java/org/eclipse/epsilon/zeta/model/emf/util/EmfModelAssistant.java
@@ -274,7 +274,6 @@ public class EmfModelAssistant {
 	/**
 	 * Register the EPackage and its nested packages in the given EPackage.Registry
 	 * @param ep					The EPackage
-	 * @param registry				The Registry
 	 */
 	public static void registerEPackageGlobally(EPackage ep) {
 		org.eclipse.emf.ecore.EPackage.Registry.INSTANCE.put(ep.getNsURI(), ep);


### PR DESCRIPTION
Removed bad tag from EmfModelAssistant#registerEPackageGlobally(EPackage)

Was stopping `mvn clean install` from completing successfully